### PR TITLE
Add optimization that simplifies fusion dask graphs in case of zarr input

### DIFF
--- a/src/multiview_stitcher/_tests/test_fusion.py
+++ b/src/multiview_stitcher/_tests/test_fusion.py
@@ -367,21 +367,23 @@ def test_direct_zarr_fusion(ndim):
     with tempfile.TemporaryDirectory() as tmpdir:
         for iview in range(nviews):
             sims_zarr[iview].data = da.to_zarr(
-                sims_zarr[iview].data,
+                sims[iview].data,
                 os.path.join(tmpdir, f"data_zarr_f{iview}.zarr"),
                 overwrite=True,
                 return_stored=True,
                 compute=True,
             )
 
-    fused_sims = [
-        fusion.fuse(
-            input_sims,
-            transform_key=METADATA_TRANSFORM_KEY,
-        )
-        for input_sims in [sims, sims_zarr]
-    ]
+        fused_sims = [
+            fusion.fuse(
+                input_sims,
+                transform_key=METADATA_TRANSFORM_KEY,
+            )
+            for input_sims in [sims, sims_zarr]
+        ]
 
-    fused_sims_c = [s.compute(scheduler="single-threaded") for s in fused_sims]
+        fused_sims_c = [
+            s.compute(scheduler="single-threaded") for s in fused_sims
+        ]
 
     assert np.allclose(*fused_sims_c)

--- a/src/multiview_stitcher/_tests/test_fusion.py
+++ b/src/multiview_stitcher/_tests/test_fusion.py
@@ -334,24 +334,26 @@ def test_fusion_chunksizes(input_chunksize):
             for idim, dim in enumerate(si_utils.SPATIAL_DIMS[-ndim:])
         )
 @pytest.mark.parametrize(
-    "ndim,",
+    "test_params",
     [
-        2,
-        3,
+        {"t": 1, "c": 1, "ndim": 3, "input_chunking": 10},
+        {"t": 1, "c": 2, "ndim": 2, "input_chunking": 10},
+        {"t": 2, "c": 2, "ndim": 2, "input_chunking": 10},
     ],
 )
-def test_circumvent_dask_for_zarr_backed_input(ndim):
+def test_circumvent_dask_for_zarr_backed_input(test_params):
     """
     Test that the circumvent_dask_for_zarr_backed_input flag works as expected.
     """
 
+    ndim = 2
     nviews = 2
     sims = [
         sample_data.generate_tiled_dataset(
             ndim=ndim,
             overlap=0,
-            N_c=1,
-            N_t=1,
+            N_c=test_params["c"],
+            N_t=test_params["t"],
             tile_size=20,
             tiles_x=2,
             tiles_y=1,
@@ -366,7 +368,7 @@ def test_circumvent_dask_for_zarr_backed_input(ndim):
     sdims = si_utils.get_spatial_dims_from_sim(sims[0])
 
     for sim in sims:
-        sim.data = sim.data.rechunk(10)
+        sim.data = sim.data.rechunk(test_params["input_chunking"])
         p = param_utils.affine_to_xaffine(param_utils.random_affine(ndim=ndim))
         si_utils.set_sim_affine(sim, p, transform_key="random")
 

--- a/src/multiview_stitcher/_tests/test_fusion.py
+++ b/src/multiview_stitcher/_tests/test_fusion.py
@@ -382,6 +382,8 @@ def test_direct_zarr_fusion(ndim):
             for input_sims in [sims, sims_zarr]
         ]
 
+        # add check that the dask graphs changed
+
         fused_sims_c = [
             s.compute(scheduler="single-threaded") for s in fused_sims
         ]

--- a/src/multiview_stitcher/fusion.py
+++ b/src/multiview_stitcher/fusion.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import warnings
 from collections.abc import Callable, Sequence
 from itertools import product
@@ -21,6 +22,8 @@ from multiview_stitcher import (
 from multiview_stitcher import spatial_image_utils as si_utils
 
 BoundingBox = dict[str, dict[str, Union[float, int]]]
+
+logger = logging.getLogger(__name__)
 
 
 def max_fusion(
@@ -258,10 +261,17 @@ def fuse(
     views_bb = [si_utils.get_stack_properties_from_sim(sim) for sim in sims]
 
     access_zarr_directly = True
+    logger.info(
+        f"Accessing zarr arrays directly for fusion: {access_zarr_directly}"
+    )
     if access_zarr_directly:
         sims_data_zarrs = [
             misc_utils.get_zarr_array_from_dask_array(sim.data) for sim in sims
         ]
+        logger.info(
+            "The following sim indices can be accessed directly from zarr arrays: "
+            f"{[isim is not None for isim, sim_data_zarr in enumerate(sims_data_zarrs)]}"
+        )
 
     merges = []
     for ns_coords in itertools.product(

--- a/src/multiview_stitcher/fusion.py
+++ b/src/multiview_stitcher/fusion.py
@@ -179,6 +179,12 @@ def fuse(
         its chunksize is used as the default. If the first tile is not a chunked dask array,
         the default chunksize defined in spatial_image_utils.py is used.
         Chunksize of the dask data array of the fused image, by default 512
+    overlap_in_pixels : int, optional
+        Overlap in pixels used for fusion, by default None
+    interpolation_order : int, optional
+        Order of transformation interpolation, by default 1
+    blending_widths : dict, optional
+        Widths of blending weights per spatial dimension, by default None
     circumvent_dask_for_zarr_backed_input: bool, optional
         Optional (experimental) optimization for input arrays created from zarr arrays
         using dask.array.from_zarr. In this case, and if this option is enabled,

--- a/src/multiview_stitcher/misc_utils.py
+++ b/src/multiview_stitcher/misc_utils.py
@@ -1,6 +1,10 @@
 import logging
 from contextlib import contextmanager
 
+import dask.array as da
+import numpy as np
+from dask import delayed
+
 
 class DisableLogger:
     def __enter__(self):
@@ -30,3 +34,43 @@ def temporary_log_level(logger, level):
     logger.setLevel(level)
     yield
     logger.setLevel(old_level)
+
+
+def get_zarr_array_from_dask_array(dask_array):
+    """
+    If `dask_array` was created using
+      - `da.from_zarr` or
+      - `da.to_zarr(return_stored=True,...),
+
+    return the underlying zarr array.
+
+    Otherwise, return None.
+
+    Note: If operations have been applied after `da.from_zarr`, this function returns None.
+    """
+    # check for from_zarr
+    keys = list(dask_array.dask.keys())
+    if not (
+        keys[0][0].startswith("from-zarr")
+        or keys[0][0].startswith("load-store-map")
+    ):
+        return None
+
+    # handle only the case when all chunks come from the same zarr array
+    unique_key_names = np.unique([k[0] for k in keys])
+    if len(unique_key_names) > 1:
+        return None
+
+    # return zarr array
+    first_value = dask_array.dask[keys[0]]
+    return first_value[1]  # zarr array
+
+
+def get_dask_array_from_slice_into_zarr_array(zarr_array, sl, chunks=None):
+    if chunks is not None:
+        raise (NotImplementedError)
+
+    d = delayed(lambda x, y: x[y])(zarr_array, sl)
+    return da.from_delayed(
+        d, shape=tuple([s.stop - s.start for s in sl]), dtype=zarr_array.dtype
+    )


### PR DESCRIPTION
This PR adds an optimization for fusing input tiles which are dask arrays created from zarr arrays.

In this case, and if the option `circumvent_dask_for_zarr_backed_input` is enabled, the fusion function will attempt to access the input arrays directly from the zarr arrays. This circumvents dask trying to feed the same input chunks into the task chains associated to different output chunks.

The optimization is experimental and optional / not performed by default.

## Example:

### Input
Tile configuration:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/65fd5dc6-fec0-48d3-8c71-c4928aa811f1" />

Dask arrays of tiles:
<img width="419" alt="image" src="https://github.com/user-attachments/assets/2779caa8-e60b-46fa-adb3-9fdeb1355277" />

### Fusion
Fused array with chunksize which is not aligned with input:
<img width="423" alt="image" src="https://github.com/user-attachments/assets/14c99555-e07e-46c0-ad51-5fc74627909b" />

### Fusion graphs

`circumvent_dask_for_zarr_backed_input = False`
<img width="887" alt="image" src="https://github.com/user-attachments/assets/6f71d9e6-d037-4cb7-80dc-1c806b30e976" />

`circumvent_dask_for_zarr_backed_input = True`
<img width="893" alt="image" src="https://github.com/user-attachments/assets/344ad46e-0a7f-4c44-9411-b4667f95547a" />

