### PR TITLE
Add support for directly viewing local and remote ome-zarrs with neuroglancer

### DIFF
--- a/src/multiview_stitcher/_tests/test_ngff_utils.py
+++ b/src/multiview_stitcher/_tests/test_ngff_utils.py
@@ -121,14 +121,24 @@ def test_ome_zarr_ng(ndim, N_t, N_c):
 
         for single_layer in [True, False]:
             ng_json = vis_utils.generate_neuroglancer_json(
-                [sim],
-                [zarr_path],
-                [
+                ome_zarr_paths=[zarr_path],
+                ome_zarr_urls=[
                     f"https://localhost:8000/{os.path.basename(zp)}"
                     for zp in [zarr_path]
                 ],
+                sims=[sim],
                 # channel_coord=sim.coords["c"].values[0],
                 transform_key=io.METADATA_TRANSFORM_KEY,
                 single_layer=single_layer,
             )
             assert len(ng_json.keys())
+
+        # without sims
+        ng_json = vis_utils.generate_neuroglancer_json(
+            ome_zarr_paths=[zarr_path],
+            ome_zarr_urls=[
+                f"https://localhost:8000/{os.path.basename(zp)}"
+                for zp in [zarr_path]
+            ],
+        )
+        assert len(ng_json.keys())

--- a/src/multiview_stitcher/ngff_utils.py
+++ b/src/multiview_stitcher/ngff_utils.py
@@ -414,4 +414,13 @@ def read_sim_from_ome_zarr(
         ngff_multiscales.images[resolution_level], transform_key=transform_key
     )
 
+    # get channel names from omero metadata if available
+    store = parse_url(zarr_path, mode="r").store
+    root = zarr.group(store=store)
+
+    if "omero" in root.attrs:
+        omero = root.attrs["omero"]
+        ch_coords = [ch["label"] for ch in omero["channels"]]
+        sim = sim.assign_coords(c=ch_coords)
+
     return sim

--- a/src/multiview_stitcher/ngff_utils.py
+++ b/src/multiview_stitcher/ngff_utils.py
@@ -133,7 +133,9 @@ def ngff_image_to_sim(ngff_im, transform_key):
 
     si_utils.set_sim_affine(
         sim,
-        param_utils.affine_to_xaffine(np.eye(len(sdims) + 1), t_coords=[0]),
+        param_utils.affine_to_xaffine(
+            np.eye(len(sdims) + 1), t_coords=sim.coords["t"].values
+        ),
         transform_key=transform_key,
     )
 


### PR DESCRIPTION
(without associated sims)

E.g.:

```python
from multiview_stitcher import vis_utils, ngff_utils

# remote ome zarr paths

ome_zarr_paths = [
    "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr",
    "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr"
]

vis_utils.view_neuroglancer(
    ome_zarr_paths=ome_zarr_paths,
)
```

Register:

```python
from multiview_stitcher import registration, spatial_image_utils, msi_utils

sims = [ngff_utils.read_sim_from_ome_zarr(ome_zarr_path) for ome_zarr_path in ome_zarr_paths]
msims = [msi_utils.get_msim_from_sim(sim) for sim in sims]

params = registration.register(
    msims,
    transform_key=spatial_image_utils.DEFAULT_TRANSFORM_KEY,
    new_transform_key="registered",
    reg_channel_index=0,
)

sims = [msi_utils.get_sim_from_msim(msim) for msim in msims]
```

Show registered:

```python
vis_utils.view_neuroglancer(
    ome_zarr_paths=ome_zarr_paths,
    sims=sims,
    transform_key="registered",
)
```

Only the transform of the first time point is shown in neuroglancer.