### PR TITLE
Ensure param coordinate order consistency after rebase with different ndim

### DIFF
--- a/src/multiview_stitcher/_tests/test_param_utils.py
+++ b/src/multiview_stitcher/_tests/test_param_utils.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from multiview_stitcher import param_utils
+from multiview_stitcher import spatial_image_utils as si_utils
+
+
+def test_rebase_param_order():
+    p1 = param_utils.identity_transform(2)
+    sim = si_utils.get_sim_from_array(
+        np.zeros([10] * 3), affine=p1, transform_key="p1"
+    )
+
+    p2 = param_utils.affine_to_xaffine(
+        param_utils.affine_from_translation([2, 3, 0])
+    )
+
+    si_utils.set_sim_affine(
+        sim, p2, transform_key="p2", base_transform_key="p1"
+    )
+
+    assert np.all(
+        p2.coords["x_in"].data
+        == si_utils.get_affine_from_sim(sim, "p2").coords["x_in"].data
+    )

--- a/src/multiview_stitcher/param_utils.py
+++ b/src/multiview_stitcher/param_utils.py
@@ -190,6 +190,11 @@ def rebase_affine(xaffine, base_affine):
         xaffines_aligned_filled[0], xaffines_aligned_filled[1]
     )
 
+    # coordinate order can change during alignment
+    rebased = rebased.sel(
+        x_in=xaffine.coords["x_in"], x_out=xaffine.coords["x_out"]
+    )
+
     return rebased
 
 


### PR DESCRIPTION
See newly added test case for the problem this PR fixes.

Reported by @folterj.