### PR TITLE
Avoid duplicating highest resolution when creating multiscale-spatial-image from spatial-image

### DIFF
--- a/src/multiview_stitcher/_tests/test_msi_utils.py
+++ b/src/multiview_stitcher/_tests/test_msi_utils.py
@@ -20,6 +20,17 @@ def test_calc_resolution_levels(dims):
     sim = si_utils.get_sim_from_array(np.ones((100,) * len(dims)), dims=dims)
     msim = msi_utils.get_msim_from_sim(sim)
 
+    # assert that for each level at least one spatial dimension is downsampled
+    previous_shape = si_utils.get_shape_from_sim(sim)
+    for scale_key in msi_utils.get_sorted_scale_keys(msim)[1:]:
+        current_shape = si_utils.get_shape_from_sim(msim[scale_key])
+        downsampled = False
+        for dim in si_utils.get_spatial_dims_from_sim(sim):
+            if current_shape[dim] < previous_shape[dim]:
+                downsampled = True
+        assert downsampled
+        previous_shape = current_shape
+
     scale_keys = msi_utils.get_sorted_scale_keys(msim)
     assert len(scale_keys) > 1
 

--- a/src/multiview_stitcher/msi_utils.py
+++ b/src/multiview_stitcher/msi_utils.py
@@ -193,31 +193,6 @@ def calc_resolution_levels(
     return res_shapes, res_rel_factors, res_abs_factors
 
 
-# def get_optimal_multi_scale_factors_from_sim(sim, min_size=512):
-#     """
-#     This is currently simply downscaling z and xy until a minimum size is reached.
-#     Probably it'd make more sense to downscale considering the dims spacing.
-#     """
-
-#     spatial_dims = si_utils.get_spatial_dims_from_sim(sim)
-#     current_shape = {dim: len(sim.coords[dim]) for dim in spatial_dims}
-#     factors = []
-#     while 1:
-#         curr_factors = {
-#             dim: 2 if current_shape[dim] >= min_size else 1
-#             for dim in current_shape
-#         }
-#         if max(curr_factors.values()) == 1:
-#             break
-#         current_shape = {
-#             dim: int(current_shape[dim] / curr_factors[dim])
-#             for dim in current_shape
-#         }
-#         factors.append(curr_factors)
-
-#     return factors
-
-
 def get_transforms_from_dataset_as_dict(dataset):
     transforms_dict = {}
     for data_var, transform in dataset.items():
@@ -252,7 +227,8 @@ def get_msim_from_sim(sim, scale_factors=None, chunks=None):
     spatial_shape = si_utils.get_shape_from_sim(sim)
 
     if scale_factors is None:
-        scale_factors = calc_resolution_levels(spatial_shape)[1][1:]
+        scale_factors = calc_resolution_levels(spatial_shape)[1]
+        scale_factors = scale_factors[1:]  # remove input scale
 
     if chunks is None:
         if isinstance(sim.data, da.Array):


### PR DESCRIPTION
There was a bug that duplicated the highest resolution in the resolution pyramid of an msim that was created from a sim