### PR TITLE
Fix handling of dask delayed output to avoid repeated execution of pairwise reg func

### DIFF
--- a/src/multiview_stitcher/registration.py
+++ b/src/multiview_stitcher/registration.py
@@ -920,7 +920,8 @@ def register_pair_of_msims(
     param_ds = xr.Dataset(
         data_vars={
             "transform": param_utils.affine_to_xaffine(affine_phys),
-            "quality": xr.DataArray(quality)
+            # xarray + dask fail if 'quality' is passed directly (?)
+            "quality": xr.DataArray((da.ones(1) * quality)[0])
         }
     )
 


### PR DESCRIPTION
Fixes https://github.com/multiview-stitcher/multiview-stitcher/issues/106

The bug here lead to each pairwise registration function being executed twice 😳. So with this fix pairwise execution speed doubles 😅🚀

Thank you @folterj for finding and reporting this 🙏 🎉