### PR TITLE
Notebook Example Fix

### DIFF
--- a/notebooks/stitching_bigstitcher_multiview.ipynb
+++ b/notebooks/stitching_bigstitcher_multiview.ipynb
@@ -312,7 +312,7 @@
     "\n",
     "    lds = viewer_utils.create_image_layer_tuples_from_msims(\n",
     "        msims_reg,\n",
-    "        transform_key='affine_registered',\n",
+    "        transform_key='translation_registered',\n",
     "        n_colors=100,\n",
     "        name_prefix='registered view',\n",
     "        contrast_limits=[0, 10],\n",


### PR DESCRIPTION
In the notebook example for "stitching_bigstitcher_multiview.ipynb" is a copy/paste error which only shows up if VISUALIZE_USING_NAPARI is set to true.

At this point in the notebook, the transform_key "affine_registered" does not yet exist.