### PR TITLE
Constrain dask until upstream issue with da.to_zarr is fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "numpy >=1.18",
-    "dask",
+    "dask <2025.11",
     "dask_image",
     "zarr",
     "xarray >=2024.10.0",


### PR DESCRIPTION
Tests are failing due to https://github.com/dask/dask/issues/12160.

Pin dask until this is fixed.