### PR TITLE
Avoid race condition during batch fusion using multiprocessing

### DIFF
--- a/src/multiview_stitcher/misc_utils.py
+++ b/src/multiview_stitcher/misc_utils.py
@@ -67,12 +67,18 @@ def process_batch_using_ray(func, block_ids, num_cpus=4):
     return
 
 
-def process_batch_using_joblib(func, block_ids, n_jobs=4):
+def process_batch_using_joblib(
+    func,
+    block_ids,
+    n_jobs=4,
+    backend='loky',
+    ):
     """
     A batch function that uses joblib for parallel processing.
     1. func: function to apply to each block_id
     2. block_ids: list of block IDs to process
     3. n_jobs: number of parallel jobs to run
+    4. backend: joblib backend to use ('threading' or 'loky' (default) for multiprocessing)
     """
 
     try:
@@ -80,7 +86,10 @@ def process_batch_using_joblib(func, block_ids, n_jobs=4):
     except ImportError:
         raise ImportError("Please install joblib to use this function.")
 
-    Parallel(n_jobs=n_jobs)(
+    Parallel(
+        n_jobs=n_jobs,
+        backend=backend
+        )(
         delayed(func)(block_id) for block_id in block_ids
     )
     return

--- a/src/multiview_stitcher/ngff_utils.py
+++ b/src/multiview_stitcher/ngff_utils.py
@@ -268,7 +268,7 @@ def write_and_return_downsampled_sim(
                     for s, sdim in zip(array.shape, dims)]
             
             # make sure output array exists with correct shape and chunks, and with `write_empty_chunks=True`
-            output_zarr_arr = zarr.open(
+            zarr.open(
                 output_zarr_array_url,
                 shape=[int(s) for s in output_shape],
                 chunks=[int(cs) for cs in chunksizes],

--- a/src/multiview_stitcher/ngff_utils.py
+++ b/src/multiview_stitcher/ngff_utils.py
@@ -266,6 +266,18 @@ def write_and_return_downsampled_sim(
             output_shape = [np.floor(s) // (downscale_factors_per_spatial_dim[sdim]
                     if sdim in sdims else 1)
                     for s, sdim in zip(array.shape, dims)]
+            
+            # make sure output array exists with correct shape and chunks, and with `write_empty_chunks=True`
+            output_zarr_arr = zarr.open(
+                output_zarr_array_url,
+                shape=[int(s) for s in output_shape],
+                chunks=[int(cs) for cs in chunksizes],
+                dtype=array.dtype,
+                config={'write_empty_chunks': True},
+                fill_value=0,
+                mode="a",
+                **zarr_array_creation_kwargs,
+            )
 
             write_downsampled_chunk_p = partial(write_downsampled_chunk, 
                 input_array=array,

--- a/src/multiview_stitcher/ngff_utils.py
+++ b/src/multiview_stitcher/ngff_utils.py
@@ -275,7 +275,7 @@ def write_and_return_downsampled_sim(
                 dtype=array.dtype,
                 config={'write_empty_chunks': True},
                 fill_value=0,
-                mode="a",
+                mode="w" if overwrite else "a",
                 **zarr_array_creation_kwargs,
             )
 


### PR DESCRIPTION
In a hard to reproduce manner, in multiprocessing mode, batch submissions that write out chunks sometimes yield "array already exists". This might come from a race condition where a chunk writing job tries to create an array that another chunk writing job already created (?).

This PR introduces a change so that the array is created before the submission of batch jobs.