### PR TITLE
LIF format reading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ czi = [
     "czifile ==2019.7.2.1",
     "imagecodecs >=2023.7.10",
 ]
+lif = [
+    "readlif",
+]
 dev = [
     "tox",
     "jupyter",

--- a/src/multiview_stitcher/io.py
+++ b/src/multiview_stitcher/io.py
@@ -15,7 +15,7 @@ except ImportError:
     AICSImage = None
 
 
-from multiview_stitcher import czi_utils
+from multiview_stitcher import czi_utils, lif_utils
 from multiview_stitcher import spatial_image_utils as si_utils
 
 METADATA_TRANSFORM_KEY = si_utils.DEFAULT_TRANSFORM_KEY
@@ -46,6 +46,9 @@ def read_mosaic_into_sims(filepath, scene_index=0):
 
     if filepath.suffix == ".czi":
         return read_mosaic_into_sims_czifile(filepath, scene_index=scene_index)
+
+    elif filepath.suffix == ".lif":
+        return read_mosaic_into_sims_readlif(filepath, scene_index=scene_index)
 
     else:
         return read_mosaic_into_sims_aicsimageio(
@@ -164,6 +167,63 @@ def read_mosaic_into_sims_aicsimageio(path, scene_index=0):
 
     return view_sims
 
+
+
+def read_mosaic_into_sims_readlif(filepath, scene_index=0):
+    """
+    Read the tiles of a LIF mosaic dataset into a list of sims.
+    This function uses readlif (instead of aicsimageio) to read the LIF file.
+
+    Parameters
+    ----------
+    filepath : str or Path
+        Path to the LIF file.
+    scene_index : int, optional
+        Index of the image / scene within the LIF file to read. Default is 0.
+
+    Returns
+    -------
+    list of SpatialImage
+        One SpatialImage per mosaic tile.
+    """
+    filepath = Path(filepath)
+
+    lif_image = lif_utils.get_lif_image(filepath, scene_index=scene_index)
+
+    n_mosaic = max(lif_image.n_mosaic, 1)
+
+    spacing = lif_utils.get_spacing_from_lif_image(lif_image)
+    tile_origins = lif_utils.get_mosaic_tile_origins(lif_image, spacing)
+
+    # TODO: channel names not available in readlif?
+    c_coords = list(range(lif_image.channels))
+
+    sims = []
+    for m in range(n_mosaic):
+        xim, _ = lif_utils.read_lif_tile_into_xim(filepath, scene_index, m)
+
+        spatial_dims = [dim for dim in xim.dims if dim in si_utils.SPATIAL_DIMS]
+
+        origin = tile_origins[m] if m < len(tile_origins) else dict.fromkeys(spatial_dims, 0.0)
+
+        xim = xim.assign_coords(
+            {sdim: xim.coords[sdim].values - xim.coords[sdim].values[0]
+             for sdim in spatial_dims}
+        )
+
+        sim = si_utils.get_sim_from_array(
+            xim.data,
+            dims=list(xim.dims),
+            scale=spacing,
+            translation=origin,
+            transform_key=METADATA_TRANSFORM_KEY,
+            c_coords=c_coords,
+            t_coords=xim.coords["t"].values if "t" in xim.dims else None,
+        )
+
+        sims.append(sim)
+
+    return sims
 
 def read_mosaic_into_sims_czifile(filename, scene_index=0):
     """

--- a/src/multiview_stitcher/lif_utils.py
+++ b/src/multiview_stitcher/lif_utils.py
@@ -1,0 +1,207 @@
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+import xarray as xr
+from dask import delayed
+
+try:
+    from readlif.reader import LifFile
+except ImportError:
+    LifFile = None
+
+
+def _check_readlif():
+    if LifFile is None:
+        raise ImportError(
+            "readlif is required to read LIF files. "
+            "Please install it using `pip install readlif`."
+        )
+
+
+def get_lif_image(filepath, scene_index=0):
+    """
+    Open a LIF file and return the LifImage for the given scene index.
+
+    Parameters
+    ----------
+    filepath : str or Path
+    scene_index : int
+
+    Returns
+    -------
+    LifImage
+    """
+    _check_readlif()
+    lif = LifFile(str(filepath))
+    return lif.get_image(scene_index)
+
+
+def get_number_of_scenes(filepath):
+    """
+    Return the number of images (scenes) in a LIF file.
+    """
+    _check_readlif()
+    lif = LifFile(str(filepath))
+    return lif.num_images
+
+
+def get_spacing_from_lif_image(lif_image):
+    """
+    Return pixel spacing in micrometers as a dict keyed by spatial dim.
+
+    LifImage.scale is (scale_x, scale_y, scale_z, scale_t) in px/µm.
+    Spacing = 1 / scale (µm/px).
+    """
+    scale_x, scale_y, scale_z, _ = lif_image.scale
+
+    spacing = {}
+    if scale_x is not None and scale_x != 0:
+        spacing["x"] = 1.0 / scale_x
+    else:
+        spacing["x"] = 1.0
+
+    if scale_y is not None and scale_y != 0:
+        spacing["y"] = 1.0 / scale_y
+    else:
+        spacing["y"] = 1.0
+
+    if lif_image.nz > 1:
+        if scale_z is not None and scale_z != 0:
+            spacing["z"] = 1.0 / scale_z
+        else:
+            spacing["z"] = 1.0
+
+    return spacing
+
+
+def get_mosaic_tile_origins(lif_image, spacing):
+    """
+    Return per-tile origins in micrometers.
+
+    mosaic_position entries are (FieldX, FieldY, PosX, PosY),
+    where PosX/PosY are stage positions in meters.
+    We convert to µm and return as dicts keyed by spatial dim.
+
+    If the image is not a mosaic, returns a single-element list with zeros.
+    """
+    has_z = "z" in spacing
+
+    if lif_image.n_mosaic <= 1 or not lif_image.mosaic_position:
+        origin = {"y": 0.0, "x": 0.0}
+        if has_z:
+            origin["z"] = 0.0
+        return [origin]
+
+    origins = []
+    for _fx, _fy, pos_x, pos_y in lif_image.mosaic_position:
+        # m -> um
+        origin = {
+            "y": pos_y * 1e6,
+            "x": pos_x * 1e6,
+        }
+        if has_z:
+            origin["z"] = 0.0
+        origins.append(origin)
+
+    return origins
+
+
+def _read_lif_tile(filepath, scene_index, m, z, t, c, shape_yx):
+    """
+    Read a single (z, t, c, m) plane from a LIF file (for dask delayed).
+
+    Returns a numpy array of shape (y, x).
+    """
+    import numpy as np
+
+    lif = LifFile(str(filepath))
+    lif_image = lif.get_image(scene_index)
+    frame = lif_image.get_frame(z=z, t=t, c=c, m=m)
+    arr = np.array(frame)
+    if arr.shape != tuple(shape_yx):
+        arr = arr.reshape(shape_yx)
+    return arr
+
+
+def read_lif_tile_into_xim(filepath, scene_index, m):
+    """
+    Read a single mosaic tile (index m) from a LIF file into an xarray DataArray.
+
+    The returned DataArray has dimensions ordered as a subset of
+    (t, c, z, y, x) depending on what dimensions exist in the image.
+
+    Parameters
+    ----------
+    filepath : str or Path
+    scene_index : int
+    m : int
+        Mosaic tile index.
+
+    Returns
+    -------
+    xr.DataArray
+    """
+    _check_readlif()
+
+    filepath = Path(filepath)
+    lif = LifFile(str(filepath))
+    lif_image = lif.get_image(scene_index)
+
+    n_t = lif_image.nt
+    n_z = lif_image.nz
+    n_c = lif_image.channels
+    ny = int(lif_image.dims.y)
+    nx = int(lif_image.dims.x)
+    bit_depth = lif_image.bit_depth[0]
+    dtype = np.uint8 if bit_depth == 8 else np.uint16
+
+    has_z = n_z > 1
+
+    # !
+    planes = []
+    for t in range(n_t):
+        c_planes = []
+        for c in range(n_c):
+            if has_z:
+                z_planes = []
+                for z in range(n_z):
+                    plane = da.from_delayed(
+                        delayed(_read_lif_tile)(
+                            filepath, scene_index, m, z, t, c, (ny, nx)
+                        ),
+                        shape=(ny, nx),
+                        dtype=dtype,
+                    )
+                    z_planes.append(plane)
+                c_planes.append(da.stack(z_planes, axis=0)) # zyx
+            else:
+                plane = da.from_delayed(
+                    delayed(_read_lif_tile)(
+                        filepath, scene_index, m, 0, t, c, (ny, nx)
+                    ),
+                    shape=(ny, nx),
+                    dtype=dtype,
+                )
+                c_planes.append(plane)  # yx
+
+        planes.append(da.stack(c_planes, axis=0))  # c(z)yx
+
+    data = da.stack(planes, axis=0)  # tc(z)yx
+
+    spacing = get_spacing_from_lif_image(lif_image)
+
+    spatial_dims = list(spacing.keys())
+    coords = {}
+    for sdim in spatial_dims:
+        size = {"x": nx, "y": ny, "z": n_z}[sdim]
+        coords[sdim] = np.arange(size) * spacing[sdim]
+
+    coords["t"] = np.arange(n_t, dtype=float)
+    coords["c"] = np.arange(n_c)
+
+    dims = ["t", "c", "z", "y", "x"] if has_z else ["t", "c", "y", "x"]
+
+    xim = xr.DataArray(data, dims=dims, coords=coords)
+
+    return xim, spacing

--- a/src/multiview_stitcher/lif_utils.py
+++ b/src/multiview_stitcher/lif_utils.py
@@ -15,7 +15,9 @@ def _check_readlif():
     if LifFile is None:
         raise ImportError(
             "readlif is required to read LIF files. "
-            "Please install it using `pip install readlif`."
+            "Please install it via the optional extra "
+            "`pip install \"multiview-stitcher[lif]\"`, "
+            "or install `readlif` directly with `pip install readlif`."
         )
 
 

--- a/src/multiview_stitcher/registration.py
+++ b/src/multiview_stitcher/registration.py
@@ -1247,6 +1247,9 @@ def register(
     sims = [msi_utils.get_sim_from_msim(msim) for msim in msims]
 
     if "c" in msi_utils.get_dims(msims[0]):
+        channel_names = sims[0].coords["c"].values
+        if len(channel_names) != len(set(channel_names)):
+            raise ValueError("Channel names must be unique.")
         if reg_channel is None:
             if reg_channel_index is None:
                 for msim in msims:


### PR DESCRIPTION
Hey @m-albert,

Thanks again for developing this great software, and it was great to catch up with you a few weeks ago :)

This PR adds support for reading Leica files (`.lif`) using `readlif` instead of `aicsimageio`. As I mentioned in our email exchange, the `aicsimageio`-based reader seems to return the tiles in incorrect positions when reading `.lif`. 

I tried to follow the style that you have for the `czifile` reader as much as I could, but feel free to request any changes :) We've used it for some samples now and it seems to be robust, though it'd be great if you can test in some other Leica acquisitions you might have access to. I've added `readlif` as an extra dependency (`pip install multiview-stitcher[lif]` should do).

The main issue I see is that I can't seem to access channel names from `readlif` directly, so for now they're dummily hardcoded as `("0", "1", ...)`. I'll try to figure out when I have some time. I haven't added tests, but happy to try to do so when I have some time too if you'd like :)

I've also included a small block regarding `xarray` slicing multiple channels in an unexpected fashion if the acquisition has duplicated channel names, which cascaded into an error downstream for most ops. The software now throws an error if that is the case, but it's probably an easy fix on your side to avoid this being a problem :)