### PR TITLE
Make fusion computation CuPy array compatible

### DIFF
--- a/src/multiview_stitcher/fusion.py
+++ b/src/multiview_stitcher/fusion.py
@@ -26,6 +26,11 @@ from multiview_stitcher import (
 )
 from multiview_stitcher import spatial_image_utils as si_utils
 
+try:
+    import cupy as cp
+except ImportError:
+    cp = None
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -734,7 +739,7 @@ def fuse_np(
         ).data
         for sim, param in zip(sims, params)
     ]
-    field_ims_t = np.array(field_ims_t)
+    field_ims_t = np.stack(field_ims_t)
 
     # get blending weights
     if fusion_requires_blending_weights:
@@ -744,9 +749,12 @@ def fuse_np(
                 source_bb=full_view_bbs[iview],
                 affine=params[iview],
                 blending_widths=blending_widths,
+                cupy=False if cp is None else
+                (True if isinstance(sims[iview].data, cp.ndarray) else False),
             )
             for iview in range(len(sims))
         ]
+        field_ws_t = np.stack(field_ws_t)
         field_ws_t = field_ws_t * ~np.isnan(field_ims_t)
         field_ws_t = weights.normalize_weights(field_ws_t)
     else:

--- a/src/multiview_stitcher/fusion.py
+++ b/src/multiview_stitcher/fusion.py
@@ -1197,6 +1197,10 @@ def prepare_block_fusion(
             output_spacing={dim: osp['spacing'][dim] for dim in sdims},
             ).data
 
+        if cp is not None:
+            fused = fused.map_blocks(
+                lambda x: cp.asnumpy(x) if isinstance(x, cp.ndarray) else x)
+
         # Write the fused chunk to the appropriate location in the Zarr array
         with dask_config.set(scheduler='single-threaded'):
             da.to_zarr(

--- a/src/multiview_stitcher/transformation.py
+++ b/src/multiview_stitcher/transformation.py
@@ -87,7 +87,7 @@ def transform_sim(
     else:
         # check if sim.data is a cupy array
         if cp is not None and isinstance(sim.data, cp.ndarray):
-            # use cupim for affine transform
+            # use cupyx.scipy.ndimage for affine transform
             matrix = cp.asarray(affine_transform_kwargs.pop("matrix"))
             out_data = cupyx.scipy.ndimage.affine_transform(
                 sim.data,

--- a/src/multiview_stitcher/transformation.py
+++ b/src/multiview_stitcher/transformation.py
@@ -6,6 +6,12 @@ from scipy.ndimage import affine_transform
 
 from multiview_stitcher import param_utils, spatial_image_utils
 
+try:
+    import cupy as cp
+    import cupyx.scipy.ndimage
+except ImportError:
+    cp = None
+
 
 def transform_sim(
     sim,
@@ -79,10 +85,20 @@ def transform_sim(
             **affine_transform_kwargs,
         )
     else:
-        out_data = affine_transform(
-            sim.data,
-            **affine_transform_kwargs,
-        )
+        # check if sim.data is a cupy array
+        if cp is not None and isinstance(sim.data, cp.ndarray):
+            # use cupim for affine transform
+            matrix = cp.asarray(affine_transform_kwargs.pop("matrix"))
+            out_data = cupyx.scipy.ndimage.affine_transform(
+                sim.data,
+                matrix=matrix,
+                **affine_transform_kwargs,
+            )
+        else:
+            out_data = affine_transform(
+                sim.data,
+                **affine_transform_kwargs,
+            )
 
     sim = si.to_spatial_image(
         out_data,

--- a/src/multiview_stitcher/weights.py
+++ b/src/multiview_stitcher/weights.py
@@ -9,6 +9,12 @@ from multiview_stitcher import transformation
 
 BoundingBox = dict[str, dict[str, Union[float, int]]]
 
+try:
+    import cupy as cp
+    import cupyx.scipy.ndimage
+except ImportError:
+    cp = None
+
 
 def calculate_required_overlap(
     method_func=None,
@@ -145,6 +151,7 @@ def get_blending_weights(
     source_bb: BoundingBox,
     affine: xr.DataArray,
     blending_widths: dict[str, float] = None,
+    cupy=False,
 ):
     """
     Calculate smooth blending weights for fusion.
@@ -207,6 +214,9 @@ def get_blending_weights(
         translation=edt_support_origin,
     )
 
+    if cp is not None and cupy:
+        edt_support.data = cp.asarray(edt_support.data)
+
     target_weights = transformation.transform_sim(
         edt_support.astype(np.float32),
         p=np.linalg.inv(affine),
@@ -243,4 +253,4 @@ def get_blending_weights(
 
     target_weights.data = cosine_weights(target_weights.data)
 
-    return target_weights
+    return target_weights.data

--- a/src/multiview_stitcher/weights.py
+++ b/src/multiview_stitcher/weights.py
@@ -103,15 +103,22 @@ def nan_gaussian_filter_dask_image(ar, *args, **kwargs):
         filtered array
     """
 
+    if cp is not None and isinstance(ar, cp.ndarray):
+        gaussian_filter_func = cupyx.scipy.ndimage.gaussian_filter
+    else:
+        gaussian_filter_func = gaussian_filter
+
+    start = time()
+
     U = ar
     nan_mask = np.isnan(U)
     V = U.copy()
     V[nan_mask] = 0
-    VV = gaussian_filter(V, *args, **kwargs)
+    VV = gaussian_filter_func(V, *args, **kwargs)
 
     W = 0 * U.copy() + 1
     W[nan_mask] = 0
-    WW = gaussian_filter(W, *args, **kwargs)
+    WW = gaussian_filter_func(W, *args, **kwargs)
 
     # avoid division by zero
     WW[nan_mask] = 1

--- a/src/multiview_stitcher/weights.py
+++ b/src/multiview_stitcher/weights.py
@@ -108,8 +108,6 @@ def nan_gaussian_filter_dask_image(ar, *args, **kwargs):
     else:
         gaussian_filter_func = gaussian_filter
 
-    start = time()
-
     U = ar
     nan_mask = np.isnan(U)
     V = U.copy()

--- a/src/multiview_stitcher/weights.py
+++ b/src/multiview_stitcher/weights.py
@@ -169,7 +169,8 @@ def get_blending_weights(
 
     Returns
     -------
-    target_weights : spatial_image
+    target_weights : dask array containing blending weights
+        for the target bounding box
     """
 
     if blending_widths is None:

--- a/src/multiview_stitcher/weights.py
+++ b/src/multiview_stitcher/weights.py
@@ -67,10 +67,10 @@ def content_based(
     transformed_views[blending_weights < 1e-7] = np.nan
 
     weights = [
-        nan_gaussian_filter_dask_image(
+        nan_gaussian_filter(
             (
                 sim_t
-                - nan_gaussian_filter_dask_image(
+                - nan_gaussian_filter(
                     sim_t, sigma=sigma_1, mode="reflect"
                 )
             )
@@ -87,7 +87,7 @@ def content_based(
     return weights
 
 
-def nan_gaussian_filter_dask_image(ar, *args, **kwargs):
+def nan_gaussian_filter(ar, *args, **kwargs):
     """
     Gaussian filter ignoring NaNs.
 

--- a/src/multiview_stitcher/weights.py
+++ b/src/multiview_stitcher/weights.py
@@ -92,15 +92,6 @@ def nan_gaussian_filter(ar, *args, **kwargs):
     Gaussian filter ignoring NaNs.
 
     https://stackoverflow.com/questions/18697532/gaussian-filtering-a-image-with-nan-in-python
-
-    Parameters
-    ----------
-    ar : da.array
-
-    Returns
-    -------
-    da.array
-        filtered array
     """
 
     if cp is not None and isinstance(ar, cp.ndarray):


### PR DESCRIPTION
Work together with @alexschroeter.

This PR adds minimal changes such that the fusion computation is friendly with dask arrays backed by cupy arrays. Also, in the case of receiving cupy arrays as input, `cupyx.scipy.ndimage.affine_transform` and `cupyx.scipy.ndimage.gaussian_filter` are used similarly to how the [dask-image dispatching mechanism](https://github.com/dask/dask-image/tree/main/dask_image/dispatch) works.

Further GPU support and optimizations might follow, this is just the lowest hanging fruit.

Fusion on cpu:

```python
from multiview_stitcher import fusion

fused_sim = fusion.fuse(
    sims,
    transform_key="stage_metadata",
)

fused_sim.data.compute()
```

Fusion on gpu:
```python
from multiview_stitcher import fusion

# send chunks to GPU
for i in range(len(sims)):
    sims[i].data = sims[i].data.map_blocks(cp.asarray)

fused_sim = fusion.fuse(
    sims,
    transform_key="stage_metadata",
)

# retrieve fused chunks from GPU
fused_sim.data = fused_sim.data.map_blocks(cp.asnumpy)

fused_sim.data.compute()
```


