### PR TITLE
Generalize vis_utils.plot_positions to work with full affine parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ for tile_array, tile_translation in zip(tile_arrays, tile_translations):
         dims=["c", "z", "y", "x"],
         scale=spacing,
         translation=tile_translation,
+        # affine=None, # (e.g. for rotated or sheared tiles)
         transform_key="stage_metadata",
         c_coords=channels,
     )

--- a/docs/code_example.md
+++ b/docs/code_example.md
@@ -36,6 +36,7 @@ for tile_array, tile_translation in zip(tile_arrays, tile_translations):
         dims=["c", "z", "y", "x"],
         scale=spacing,
         translation=tile_translation,
+        # affine=None, # (e.g. for rotated or sheared tiles)
         transform_key="stage_metadata",
         c_coords=channels,
     )

--- a/src/multiview_stitcher/_tests/quickstart/0_data_preparation.py
+++ b/src/multiview_stitcher/_tests/quickstart/0_data_preparation.py
@@ -23,6 +23,7 @@ for tile_array, tile_translation in zip(tile_arrays, tile_translations):
         dims=["c", "z", "y", "x"],
         scale=spacing,
         translation=tile_translation,
+        # affine=None, # (e.g. for rotated or sheared tiles)
         transform_key="stage_metadata",
         c_coords=channels,
     )

--- a/src/multiview_stitcher/vis_utils.py
+++ b/src/multiview_stitcher/vis_utils.py
@@ -283,34 +283,18 @@ def plot_positions(
 
 def plot_stack_props(stack_props, ax, color="black", size=10, linewidth=1):
     ndim = mv_graph.get_ndim_from_stack_props(stack_props)
-    faces = mv_graph.get_faces_from_stack_props(stack_props)
+    vertices = mv_graph.get_vertices_from_stack_props(stack_props)
 
-    # get line segments
-    line_segments = []
-
-    if ndim == 3:
-        for face in faces:
-            inds = np.argsort(np.linalg.norm(face[1:] - face[0], axis=-1))
-            line_segments.append([face[0], face[inds[0] + 1]])
-            line_segments.append([face[0], face[inds[1] + 1]])
-            line_segments.append(
-                [
-                    face[inds[0] + 1],
-                    face[inds[0] + 1] + face[inds[1] + 1] - face[0],
-                ]
-            )
-            line_segments.append(
-                [
-                    face[inds[1] + 1],
-                    face[inds[1] + 1] + face[inds[0] + 1] - face[0],
-                ]
-            )
-
-    elif ndim == 2:
-        for face in faces:
-            line_segments.append([face[0], face[1]])
-
-    line_segments = np.array(line_segments)
+    # Build box edges by topology (index hypercube), then map to transformed
+    # vertex coordinates. This is robust for arbitrary affine transforms.
+    gv = np.array(list(np.ndindex(tuple([2] * ndim))))
+    edge_pairs = [
+        (i, j)
+        for i in range(len(gv))
+        for j in range(i + 1, len(gv))
+        if np.sum(np.abs(gv[i] - gv[j])) == 1
+    ]
+    line_segments = np.array([[vertices[i], vertices[j]] for i, j in edge_pairs])
 
     if ndim == 2:
         line_segments = np.concatenate(

--- a/src/multiview_stitcher/vis_utils.py
+++ b/src/multiview_stitcher/vis_utils.py
@@ -20,6 +20,7 @@ from multiview_stitcher import (
     msi_utils,
     mv_graph,
     ngff_utils,
+    param_utils,
     spatial_image_utils,
 )
 
@@ -509,7 +510,7 @@ def plot_tile_pair_image_metrics(
                         for idim, dim in enumerate(spatial_dims)
                     },
                     "shape": {dim: 2 for dim in spatial_dims},
-                    "transform": bbox_transform,
+                    "transform": param_utils.affine_to_xaffine(bbox_transform),
                 }
                 plot_stack_props(sp, ax, color=color, linewidth=2)
 


### PR DESCRIPTION
Previously there was a bug for negative shear angles.

E.g.
```python
from multiview_stitcher import spatial_image_utils as si_utils
from multiview_stitcher import vis_utils
import numpy as np

%matplotlib ipympl

im = np.random.randint(0, 100, (20, 101, 102))

def build_3d_shear_affine(angle):
    # Create a 3D shear affine transformation matrix
    shear_matrix = np.array([
        [1, np.tan(np.radians(-angle)), 0, 0],
        [0, 1                        , 0, 0],
        [0, 0                        , 1, 0],
        [0, 0                        , 0, 1]])
    return shear_matrix

shear_angle = 45
spacing = {'z': 5, 'y': 1, 'x': 1}
translation = {'z': 0, 'y': 0, 'x': 0}

sim = si_utils.get_sim_from_array(
    im,
    scale=spacing,
    translation=translation,
    affine=build_3d_shear_affine(shear_angle),
    transform_key="stage_metadata",
)

vis_utils.plot_positions([sim], transform_key="stage_metadata")
```
