### PR TITLE
Rename 'use_cupy=' parameter to `backend=` for future compatibility

### DIFF
--- a/docs/built_in_methods_fusion.md
+++ b/docs/built_in_methods_fusion.md
@@ -47,7 +47,7 @@ contribute at each pixel.
 | `sample_boundary_erosion_px` | `0` | Pixels to erode the union coverage mask before zeroing output; removes the bright-ring artefact at the outer sample boundary. |
 
 **GPU support:** When the input arrays are `cupy` arrays, convolutions run on
-the GPU via `cupyx.scipy.ndimage`. Use `use_cupy=True` in `fusion.fuse` to
+the GPU via `cupyx.scipy.ndimage`. Use `backend="cupy"` in `fusion.fuse` to
 enable this automatically.
 
 **Chunk overlap:** `multi_view_deconvolution` declares a
@@ -70,7 +70,7 @@ fused = fusion.fuse(
         na=0.8,
         wavelength_um=0.52,
     ),
-    use_cupy=True,  # optional – omit for CPU-only
+    backend="cupy",  # optional – omit for CPU-only
 )
 ```
 

--- a/docs/extension_api_fusion.md
+++ b/docs/extension_api_fusion.md
@@ -58,6 +58,6 @@ As with custom fusion functions, optional arguments are only passed when they ar
 
 ## CuPy support
 
-If `fuse(..., use_cupy=True)` is passed, the fusion and weight functions receive CuPy arrays as input and should return a CuPy array as output. The built-in fusion and weight functions support CuPy arrays (in large part by using the NumPy Array API which transparently dispatches functions to their numpy or cupy implementations based on the input array type).
+If `fuse(..., backend="cupy")` is passed, the fusion and weight functions receive CuPy arrays as input and should return a CuPy array as output. The built-in fusion and weight functions support CuPy arrays (in large part by using the NumPy Array API which transparently dispatches functions to their numpy or cupy implementations based on the input array type).
 
 See [GPU support](gpu_support.md) for further details and examples.

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,7 +34,7 @@ Below is a list of features which are either already implemented or are on the r
 
 - [x] Modular API to plug in different fusion and weight functions
 - [ ] Support for fusion label maps
-- [x] GPU-accelerated fusion via `use_cupy=True`
+- [x] GPU-accelerated fusion via `backend="cupy"`
 
 ### Supported fusion methods:
 

--- a/docs/fusion_overview.md
+++ b/docs/fusion_overview.md
@@ -64,6 +64,7 @@ fused_msim["scale0/image"].data.compute()
 | `output_zarr_url` | `None` | If set, fuse directly to a Zarr store and return a store-backed `SpatialImage` (recommended for large datasets) |
 | `zarr_options` | `None` | Options for Zarr output (see below) |
 | `batch_options` | `None` | Options for parallel batch processing of chunks when `output_zarr_url` is set |
+| `backend` | `None` | Compute backend: `None` or `"numpy"` for CPU, `"cupy"` for GPU (requires CuPy) |
 
 ---
 
@@ -205,13 +206,13 @@ fused_sim = fusion.fuse(
 
 ## GPU acceleration
 
-Pass `use_cupy=True` to run resampling, blending weight calculation and fusion on the GPU.
+Pass `backend="cupy"` to run resampling, blending weight calculation and fusion on the GPU.
 
 ```python
 fused_sim = fusion.fuse(
     images=sims,
     transform_key="translation_registered",
-    use_cupy=True,
+    backend="cupy",
 )
 ```
 

--- a/docs/gpu_support.md
+++ b/docs/gpu_support.md
@@ -1,6 +1,6 @@
 # GPU support
 
-Fusion supports GPU acceleration via [CuPy](https://cupy.dev/). Pass `use_cupy=True` to `fusion.fuse` and `multiview-stitcher` will transfer each input chunk to the GPU, run resampling, blending, and the fusion function there, and return a regular NumPy-backed output.
+Fusion supports GPU acceleration via [CuPy](https://cupy.dev/). Pass `backend="cupy"` to `fusion.fuse` and `multiview-stitcher` will transfer each input chunk to the GPU, run resampling, blending, and the fusion function there, and return a regular NumPy-backed output.
 
 ## Installation
 
@@ -14,13 +14,13 @@ from multiview_stitcher import fusion
 fused_sim = fusion.fuse(
     images=sims, # or msims for multiscale
     transform_key="stage_metadata",
-    use_cupy=True,
+    backend="cupy",
 )
 
 fused_sim.data.compute()
 ```
 
-`use_cupy=True` also works with `output_zarr_url` for large datasets. In this case, setting `n_jobs` as in the example below allows limiting the number of parallel GPU batch processes, which can help manage GPU memory usage:
+`backend="cupy"` also works with `output_zarr_url` for large datasets. In this case, setting `n_jobs` as in the example below allows limiting the number of parallel GPU batch processes, which can help manage GPU memory usage:
 
 ```python
 from multiview_stitcher import fusion, misc_utils
@@ -28,7 +28,7 @@ from multiview_stitcher import fusion, misc_utils
 fused_sim = fusion.fuse(
     images=msims,
     transform_key="stage_metadata",
-    use_cupy=True,
+    backend="cupy",
     output_zarr_url="fused.ome.zarr",
     zarr_options={
         "ome_zarr": True

--- a/docs/troubleshoot_fusion.md
+++ b/docs/troubleshoot_fusion.md
@@ -8,7 +8,7 @@ For fusing large datasets, it is recommended to stream the fused result directly
 
 ## GPU memory issues
 
-When using `use_cupy=True` for GPU acceleration, the dask scheduler may dispatch too many tasks to the GPU in parallel, which can lead to out-of-memory errors on the GPU. To mitigate this, you can
+When using `backend="cupy"` for GPU acceleration, the dask scheduler may dispatch too many tasks to the GPU in parallel, which can lead to out-of-memory errors on the GPU. To mitigate this, you can
 
 1) Fuse to zarr directly `fuse(..., output_zarr_url=)` and limit the number of parallel tasks (see [GPU support](gpu_support.md) for an example of how to do this or
 2) Limit the number of parallel dask tasks when fusing to an in-memory dask array by setting e.g.
@@ -18,6 +18,6 @@ with dask.config.set({"scheduler": "single-threaded"}):
     fused_sim = fusion.fuse(
         images=sims,
         transform_key="stage_metadata",
-        use_cupy=True,
+        backend="cupy",
     )
 ```

--- a/src/multiview_stitcher/_tests/test_fusion.py
+++ b/src/multiview_stitcher/_tests/test_fusion.py
@@ -798,7 +798,7 @@ def test_fuse_to_zarr():
 
 
 @pytest.mark.parametrize("backend", ["dask", "zarr"])
-def test_fuse_use_cupy(backend):
+def test_fuse_with_cupy_backend(data_backend):
     try:
         import cupy as cp
     except ImportError:
@@ -815,7 +815,7 @@ def test_fuse_use_cupy(backend):
     )
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        if backend == "zarr":
+        if data_backend == "zarr":
             sims = [
                 _sim_to_zarr_backed_sim(
                     sim,
@@ -828,7 +828,7 @@ def test_fuse_use_cupy(backend):
         fused = fusion.fuse(
             sims,
             transform_key=METADATA_TRANSFORM_KEY,
-            use_cupy=True,
+            backend="cupy",
         ).compute(scheduler="single-threaded")
 
     assert fused.dtype == sims[0].dtype

--- a/src/multiview_stitcher/_tests/test_fusion.py
+++ b/src/multiview_stitcher/_tests/test_fusion.py
@@ -797,7 +797,7 @@ def test_fuse_to_zarr():
         assert fused.max().compute() > 0
 
 
-@pytest.mark.parametrize("backend", ["dask", "zarr"])
+@pytest.mark.parametrize("data_backend", ["dask", "zarr"])
 def test_fuse_with_cupy_backend(data_backend):
     try:
         import cupy as cp

--- a/src/multiview_stitcher/fusion/_core.py
+++ b/src/multiview_stitcher/fusion/_core.py
@@ -144,7 +144,7 @@ def _fuse_block_zarr_backed(
     interpolation_order,
     blending_widths,
     shrink_distance,
-    use_cupy=False,
+    backend=None,
 ):
     """
     Compute fused output for a single chunk from zarr-backed input sims.
@@ -227,7 +227,7 @@ def _fuse_block_zarr_backed(
         full_view_bbs=full_view_bbs,
         blending_widths=blending_widths,
         shrink_distance=shrink_distance,
-        use_cupy=use_cupy,
+        backend=backend,
     )
 
     # Restore the z-axis removed for planewise fusion.
@@ -322,7 +322,7 @@ def fuse(
     output_zarr_url: str | None = None,
     zarr_options: dict | None = None,
     batch_options: dict | None = None,
-    use_cupy: bool = False,
+    backend: str | None = None,
     sims: list | None = None,
 ):
     """
@@ -405,14 +405,14 @@ def fuse(
             (n_batch>1 only compatible with a provided batch_func). By default 1.
         - batch_func_kwargs: dict, optional
             Additional keyword arguments passed to batch_func.
-    use_cupy : bool, optional
-        If True, each input tile chunk is transferred to the GPU (via
-        ``cupy.asarray``) immediately before fusion and the result is moved
-        back to NumPy with ``cupy.asnumpy`` before it is returned.  This
-        means resampling (affine transform), blending-weight computation, and
-        the fusion function all run on the GPU (for fusion functions that support
-        cupy array input). Requires CuPy to be installed; raises ``ImportError``
-        if CuPy is not available.  By default False.
+    backend : str or None, optional
+        Compute backend to use for fusion. "numpy" (default) runs on the
+        CPU. "cupy" transfers each input chunk to the GPU via
+        cupy.asarray, runs resampling, blending-weight computation, and
+        the fusion function on the GPU, then returns a NumPy-backed result via
+        cupy.asnumpy. Requires CuPy to be installed; raises
+        ImportError if CuPy is not available. None is equivalent to
+        "numpy".
     Returns
     -------
     SpatialImage or MultiscaleSpatialImage
@@ -495,7 +495,7 @@ def fuse(
                 output_zarr_url=output_zarr_url,
                 zarr_options=zarr_options,
                 batch_options=batch_options,
-                use_cupy=use_cupy,
+                backend=backend,
             )
 
             if (zarr_options or {}).get("ome_zarr", False):
@@ -563,7 +563,7 @@ def fuse(
                     overlap_in_pixels=overlap_in_pixels,
                     interpolation_order=interpolation_order,
                     blending_widths=blending_widths,
-                    use_cupy=use_cupy,
+                    backend=backend,
                 )
             )
 
@@ -616,7 +616,7 @@ def fuse(
             "overlap_in_pixels": overlap_in_pixels,
             "interpolation_order": interpolation_order,
             "blending_widths": blending_widths,
-            "use_cupy": use_cupy,
+            "backend": backend,
         }
 
         # Prepare block fusion and process in batches
@@ -949,7 +949,7 @@ def fuse(
                 interpolation_order=interpolation_order,
                 blending_widths=blending_widths,
                 shrink_distance=shrink_distance,
-                use_cupy=use_cupy,
+                backend=backend,
             )
         else:
             # === dask path: per-chunk delayed tasks ===
@@ -1046,7 +1046,7 @@ def fuse(
                     full_view_bbs=full_view_bbs,
                     blending_widths=blending_widths,
                     shrink_distance=shrink_distance,
-                    use_cupy=use_cupy,
+                    backend=backend,
                 )
 
                 fused_output_chunk = da.from_delayed(
@@ -1121,7 +1121,7 @@ def fuse_np(
     origins: Sequence[dict[str, float]] = None,
     blending_widths: dict[float] = None,
     shrink_distance=0,
-    use_cupy: bool = False,
+    backend: str | None = None,
 ):
     """
     Fuse tiles from in-memory slices.
@@ -1166,10 +1166,10 @@ def fuse_np(
     #             translation=origins[isim],
     #         )
 
-    if use_cupy:
+    if backend == "cupy":
         if cp is None:
             raise ImportError(
-                "CuPy is not installed. Install it to use use_cupy=True."
+                "CuPy is not installed. Install it to use backend='cupy'."
             )
         sims = [
             sim.copy(data=cp.asarray(si_utils._get_backend_data(sim)))
@@ -1219,7 +1219,7 @@ def fuse_np(
                 affine=params[iview],
                 blending_widths=blending_widths,
                 shrink_distance=shrink_distance,
-                cupy=use_cupy,
+                cupy=(backend == "cupy"),
             )
             for iview in range(len(sims))
         ]


### PR DESCRIPTION
…in fusion functions and documentation.

While at first `use_cupy=` made more sense to me, this change aims to prevent future backward compatibility issues after proper backend infrastructure is implemented (see https://github.com/multiview-stitcher/multiview-stitcher/pull/140).